### PR TITLE
Fix Navbar home link

### DIFF
--- a/Frontend/src/components/Navbar/index.jsx
+++ b/Frontend/src/components/Navbar/index.jsx
@@ -70,7 +70,7 @@ const Navbar = () => {
         <div className={`navbar-menu ${isMenuOpen ? 'active' : ''}`}>
           {!token ? (
             <>
-              <Link to="/\" className="nav-link\" onClick={closeMenu}>
+              <Link to="/" className="nav-link" onClick={closeMenu}>
                 🏠 Accueil
               </Link>
               <Link to="/register-user" className="nav-link" onClick={closeMenu}>


### PR DESCRIPTION
## Summary
- fix incorrect escape characters in Navbar link

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684746248c14832d8ebaa04e5fcd6eed