### PR TITLE
Fix dotenv path for backend

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,4 +1,6 @@
+# URL de connexion MongoDB
 MONGO_URI=mongodb://localhost:27017/crm-database
+# ou MONGODB_URI
 PORT=5000
 NODE_ENV=development
 JWT_SECRET=votre_secret_jwt_tres_securise

--- a/Backend/app.js
+++ b/Backend/app.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const cors = require("cors");
-require("dotenv").config();
+const path = require("path");
+require("dotenv").config({ path: path.resolve(__dirname, ".env") });
 
 // Import des configurations
 const connectDB = require("./config/database");

--- a/Backend/config/database.js
+++ b/Backend/config/database.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    const mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/crm-database';
+    const mongoURI = process.env.MONGO_URI || process.env.MONGODB_URI || 'mongodb://localhost:27017/crm-database';
     
     console.log('🔍 Tentative de connexion à MongoDB:', mongoURI);
     

--- a/Backend/scripts/generate100Clients.js
+++ b/Backend/scripts/generate100Clients.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 // Import des modèles
 const User = require('../models/user');

--- a/Backend/scripts/generate25Users.js
+++ b/Backend/scripts/generate25Users.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 // Import des modèles
 const User = require('../models/user');

--- a/Backend/scripts/seedData.js
+++ b/Backend/scripts/seedData.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 // Import des modèles
 const User = require('../models/user');

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ cp .env.example .env
 
 Modifier le fichier `.env` avec vos configurations :
 ```env
+# URL de connexion MongoDB
 MONGO_URI=mongodb://localhost:27017/crm-database
+# ou utilisez MONGODB_URI
 PORT=5000
 NODE_ENV=development
 JWT_SECRET=votre_secret_jwt_tres_securise
@@ -110,7 +112,7 @@ crm-application/
 ## 🔧 Configuration des variables d'environnement
 
 ### Backend (.env)
-- `MONGO_URI` : URL de connexion MongoDB
+- `MONGO_URI` / `MONGODB_URI` : URL de connexion MongoDB
 - `PORT` : Port du serveur (défaut: 5000)
 - `NODE_ENV` : Environnement (development/production)
 - `JWT_SECRET` : Clé secrète pour JWT


### PR DESCRIPTION
## Summary
- ensure `.env` loads when backend scripts are run from outside the folder
- recognize `MONGODB_URI` as an alternative database environment variable

## Testing
- `npm test --prefix Backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68474ca2384c832dad1c88735594aa3f