### PR TITLE
Add placeholder pages for footer links

### DIFF
--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -13,6 +13,20 @@ import Terms from "./pages/Terms/Terms";
 import Privacy from "./pages/Privacy/Privacy";
 import Error from "./pages/Error/Index";
 import ProtectedRoute from "./components/ProtectedRoute/Index";
+import Features from "./pages/Features/Index";
+import Pricing from "./pages/Pricing/Index";
+import Demo from "./pages/Demo/Index";
+import Integrations from "./pages/Integrations/Index";
+import Help from "./pages/Help/Index";
+import Tutorials from "./pages/Tutorials/Index";
+import Blog from "./pages/Blog/Index";
+import ApiDocs from "./pages/ApiDocs/Index";
+import About from "./pages/About/Index";
+import Careers from "./pages/Careers/Index";
+import Contact from "./pages/Contact/Index";
+import Press from "./pages/Press/Index";
+import Cookies from "./pages/Cookies/Index";
+import Gdpr from "./pages/Gdpr/Index";
 import "./utils/styles/global.scss";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
@@ -31,6 +45,20 @@ ReactDOM.createRoot(document.getElementById("root")).render(
             <Route path="/login" element={<Login />} />
             <Route path="/terms" element={<Terms />} />
             <Route path="/privacy" element={<Privacy />} />
+            <Route path="/features" element={<Features />} />
+            <Route path="/pricing" element={<Pricing />} />
+            <Route path="/demo" element={<Demo />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+            <Route path="/tutorials" element={<Tutorials />} />
+            <Route path="/blog" element={<Blog />} />
+            <Route path="/api-docs" element={<ApiDocs />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/careers" element={<Careers />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/press" element={<Press />} />
+            <Route path="/cookies" element={<Cookies />} />
+            <Route path="/gdpr" element={<Gdpr />} />
             
             {/* Routes protégées */}
             <Route

--- a/Frontend/src/pages/About/Index.jsx
+++ b/Frontend/src/pages/About/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const About = () => (
+  <div className="placeholder-page">
+    <h1>About</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default About;

--- a/Frontend/src/pages/ApiDocs/Index.jsx
+++ b/Frontend/src/pages/ApiDocs/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const ApiDocs = () => (
+  <div className="placeholder-page">
+    <h1>ApiDocs</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default ApiDocs;

--- a/Frontend/src/pages/Blog/Index.jsx
+++ b/Frontend/src/pages/Blog/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Blog = () => (
+  <div className="placeholder-page">
+    <h1>Blog</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Blog;

--- a/Frontend/src/pages/Careers/Index.jsx
+++ b/Frontend/src/pages/Careers/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Careers = () => (
+  <div className="placeholder-page">
+    <h1>Careers</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Careers;

--- a/Frontend/src/pages/Contact/Index.jsx
+++ b/Frontend/src/pages/Contact/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Contact = () => (
+  <div className="placeholder-page">
+    <h1>Contact</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Contact;

--- a/Frontend/src/pages/Cookies/Index.jsx
+++ b/Frontend/src/pages/Cookies/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Cookies = () => (
+  <div className="placeholder-page">
+    <h1>Cookies</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Cookies;

--- a/Frontend/src/pages/Demo/Index.jsx
+++ b/Frontend/src/pages/Demo/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Demo = () => (
+  <div className="placeholder-page">
+    <h1>Demo</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Demo;

--- a/Frontend/src/pages/Features/Index.jsx
+++ b/Frontend/src/pages/Features/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Features = () => (
+  <div className="placeholder-page">
+    <h1>Features</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Features;

--- a/Frontend/src/pages/Gdpr/Index.jsx
+++ b/Frontend/src/pages/Gdpr/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Gdpr = () => (
+  <div className="placeholder-page">
+    <h1>Gdpr</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Gdpr;

--- a/Frontend/src/pages/Help/Index.jsx
+++ b/Frontend/src/pages/Help/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Help = () => (
+  <div className="placeholder-page">
+    <h1>Help</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Help;

--- a/Frontend/src/pages/Integrations/Index.jsx
+++ b/Frontend/src/pages/Integrations/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Integrations = () => (
+  <div className="placeholder-page">
+    <h1>Integrations</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Integrations;

--- a/Frontend/src/pages/Placeholder/placeholder.scss
+++ b/Frontend/src/pages/Placeholder/placeholder.scss
@@ -1,0 +1,18 @@
+.placeholder-page {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+}
+
+.placeholder-page h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.placeholder-page p {
+  color: #666;
+}

--- a/Frontend/src/pages/Press/Index.jsx
+++ b/Frontend/src/pages/Press/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Press = () => (
+  <div className="placeholder-page">
+    <h1>Press</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Press;

--- a/Frontend/src/pages/Pricing/Index.jsx
+++ b/Frontend/src/pages/Pricing/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Pricing = () => (
+  <div className="placeholder-page">
+    <h1>Pricing</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Pricing;

--- a/Frontend/src/pages/Tutorials/Index.jsx
+++ b/Frontend/src/pages/Tutorials/Index.jsx
@@ -1,0 +1,10 @@
+import '../Placeholder/placeholder.scss';
+
+const Tutorials = () => (
+  <div className="placeholder-page">
+    <h1>Tutorials</h1>
+    <p>Cette page est en construction.</p>
+  </div>
+);
+
+export default Tutorials;


### PR DESCRIPTION
## Summary
- add placeholder page style
- create empty pages for every footer link
- hook up routes to the new pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684751f5bda8832dab0c992bd867a82c