### PR TITLE
Fix API base URL

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,6 +1,7 @@
 # Configuration de l'API Backend
 VITE_API_URL=http://localhost:5000
-VITE_API_BASE_URL=http://localhost:5000/api
+# When running `npm run dev` Vite proxies `/api` to the backend
+VITE_API_BASE_URL=/api
 
 # Configuration de l'application
 VITE_APP_NAME=CRM Frontend

--- a/Frontend/src/config/api.js
+++ b/Frontend/src/config/api.js
@@ -1,6 +1,7 @@
 // Configuration centralisée de l'API
 const API_CONFIG = {
-  BASE_URL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
+  // Use relative path by default so Vite's proxy works in development
+  BASE_URL: import.meta.env.VITE_API_BASE_URL || '/api',
   FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL || 'http://localhost:5173',
   TIMEOUT: 10000, // 10 secondes
 };

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ cp .env.example .env
 Modifier le fichier `.env` avec vos configurations :
 ```env
 VITE_API_URL=http://localhost:5000
-VITE_API_BASE_URL=http://localhost:5000/api
+# During development the frontend uses a proxy, so `/api` is sufficient
+VITE_API_BASE_URL=/api
 VITE_FRONTEND_URL=http://localhost:5173
 VITE_NODE_ENV=development
 ```


### PR DESCRIPTION
## Summary
- use relative `/api` path as default API base URL so the Vite proxy is used during development
- document the new default in README and env example

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769df3574832daac64a140e7a5428