### PR TITLE
Fix notifications not persisting

### DIFF
--- a/Frontend/src/components/Dashboard/Notifications/notifications.jsx
+++ b/Frontend/src/components/Dashboard/Notifications/notifications.jsx
@@ -11,8 +11,20 @@ const Notifications = () => {
   const [selectedNotifications, setSelectedNotifications] = useState([]);
 
   useEffect(() => {
-    generateNotifications();
+    const stored = localStorage.getItem('notificationsData');
+    if (stored) {
+      setNotifications(JSON.parse(stored));
+      setLoading(false);
+    } else {
+      generateNotifications();
+    }
   }, []);
+
+  useEffect(() => {
+    if (!loading) {
+      localStorage.setItem('notificationsData', JSON.stringify(notifications));
+    }
+  }, [notifications, loading]);
 
   const generateNotifications = async () => {
     try {


### PR DESCRIPTION
## Summary
- keep notification state in localStorage so actions persist across refreshes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in Frontend *(fails: Missing script: "test")*
- `npm test` in Backend *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68477a5393bc832db27c89d46a553dcc