### PR TITLE
Add funnel site-last schema

### DIFF
--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
@@ -26,10 +26,10 @@ const BusinessCard = ({ userId, user }) => {
     conversions: 0
   });
 
-  // ✅ SCHÉMAS CORRIGÉS: Génération de leads avec site web EN PREMIER
+  // ✅ SCHÉMAS CORRIGÉS: Séquences d'actions prédéfinies
   const actionSchemas = {
     'lead-generation': {
-      name: '🚀 Génération de Leads',
+      name: 'Génération de Leads',
       description: 'Site web immédiat puis formulaire de contact pour maximiser les conversions',
       icon: '🚀📝',
       sequence: 'Site web (1s) → Formulaire (2s)',
@@ -37,6 +37,17 @@ const BusinessCard = ({ userId, user }) => {
       actions: [
         { type: 'website', order: 1, delay: 1000, active: true, url: 'https://www.votre-site.com' },
         { type: 'form', order: 2, delay: 2000, active: true }
+      ]
+    },
+    'form-website': {
+      name: '📝 Formulaire puis Site',
+      description: 'Collecte des informations avant de rediriger vers votre site web',
+      icon: '📝🌐',
+      sequence: 'Formulaire (1s) → Site web (2s)',
+      category: 'Engagement progressif',
+      actions: [
+        { type: 'form', order: 1, delay: 1000, active: true },
+        { type: 'website', order: 2, delay: 2000, active: true, url: 'https://www.votre-site.com' }
       ]
     },
     'website-only': {
@@ -70,6 +81,18 @@ const BusinessCard = ({ userId, user }) => {
         { type: 'website', order: 1, delay: 1000, active: true, url: 'https://www.votre-site.com' },
         { type: 'form', order: 2, delay: 2000, active: true },
         { type: 'download', order: 3, delay: 3000, active: true, file: 'carte-visite' }
+      ]
+    },
+    'funnel-site-last': {
+      name: '🎯 Site en Dernier',
+      description: 'Formulaire puis téléchargement avant d\'ouvrir le site web',
+      icon: '📝📥🌐',
+      sequence: 'Formulaire (1s) → Carte (2s) → Site web (3s)',
+      category: 'Tunnel de conversion',
+      actions: [
+        { type: 'form', order: 1, delay: 1000, active: true },
+        { type: 'download', order: 2, delay: 2000, active: true, file: 'carte-visite' },
+        { type: 'website', order: 3, delay: 3000, active: true, url: 'https://www.votre-site.com' }
       ]
     },
     'contact-only': {
@@ -138,18 +161,15 @@ const BusinessCard = ({ userId, user }) => {
         action.active && action.type === 'website'
       );
       
-      let targetUrl;
+      const targetUrl = `${FRONTEND_ROUTES.CLIENT_REGISTER(userId)}`;
+
       if (redirectAction && redirectAction.url) {
         try {
-          const url = new URL(redirectAction.url);
-          targetUrl = `${window.location.origin}/register-client/${encodeURIComponent(redirectAction.url)}`;
-          console.log("🌐 URL de redirection construite:", targetUrl);
+          new URL(redirectAction.url); // validation simple
+          console.log("🌐 URL de redirection détectée:", redirectAction.url);
         } catch (urlError) {
           console.error("❌ URL invalide:", redirectAction.url);
-          targetUrl = `${FRONTEND_ROUTES.CLIENT_REGISTER(userId)}`;
         }
-      } else {
-        targetUrl = `${FRONTEND_ROUTES.CLIENT_REGISTER(userId)}`;
       }
       
       setQrValue(targetUrl);

--- a/Frontend/src/pages/RegisterClient/Index.jsx
+++ b/Frontend/src/pages/RegisterClient/Index.jsx
@@ -98,16 +98,19 @@ const RegisterClient = () => {
     const hasWebsite = sortedActions.some(a => a.type === 'website');
     const hasForm = sortedActions.some(a => a.type === 'form');
     const hasDownload = sortedActions.some(a => a.type === 'download');
+    const websiteIndex = sortedActions.findIndex(a => a.type === 'website');
+    const formIndex = sortedActions.findIndex(a => a.type === 'form');
+    const downloadIndex = sortedActions.findIndex(a => a.type === 'download');
 
     let detectedSchema = '';
     if (hasWebsite && !hasForm && !hasDownload) {
       detectedSchema = 'website-only';
     } else if (hasWebsite && hasForm && !hasDownload) {
-      detectedSchema = 'lead-generation';
+      detectedSchema = websiteIndex > formIndex ? 'form-website' : 'lead-generation';
     } else if (!hasWebsite && hasForm && hasDownload) {
       detectedSchema = 'contact-download';
     } else if (hasWebsite && hasForm && hasDownload) {
-      detectedSchema = 'complete-funnel';
+      detectedSchema = (websiteIndex > formIndex && websiteIndex > downloadIndex) ? 'funnel-site-last' : 'complete-funnel';
     } else if (!hasWebsite && hasForm && !hasDownload) {
       detectedSchema = 'contact-only';
     } else if (!hasWebsite && !hasForm && hasDownload) {
@@ -128,6 +131,10 @@ const RegisterClient = () => {
       case 'lead-generation':
         await executeLeadGenerationSchema(sortedActions);
         break;
+
+      case 'form-website':
+        await executeFormWebsiteSchema(sortedActions);
+        break;
       
       case 'contact-download':
         await executeContactDownloadSchema(sortedActions);
@@ -135,6 +142,10 @@ const RegisterClient = () => {
       
       case 'complete-funnel':
         await executeCompleteFunnelSchema(sortedActions);
+        break;
+
+      case 'funnel-site-last':
+        await executeFunnelSiteLastSchema(sortedActions);
         break;
       
       case 'contact-only':
@@ -210,7 +221,24 @@ const RegisterClient = () => {
     }
   };
 
-  // ✅ SCHÉMA 3: Contact → Carte (form → download)
+  // ✅ SCHÉMA 3: Formulaire puis Site Web (form → website)
+  const executeFormWebsiteSchema = async (actions) => {
+    console.log('📝🌐 Exécution: Formulaire puis Site Web');
+    setShowForm(true);
+
+    const websiteAction = actions.find(a => a.type === 'website');
+    if (websiteAction) {
+      setPendingActions([websiteAction]);
+    }
+
+    setExecutionStatus([{ 
+      action: 'form',
+      status: 'form-shown',
+      message: 'Formulaire affiché - Site web après soumission'
+    }]);
+  };
+
+  // ✅ SCHÉMA 4: Contact → Carte (form → download)
   const executeContactDownloadSchema = async (actions) => {
     console.log('📝 Exécution: Contact → Carte');
     setShowForm(true);
@@ -227,7 +255,7 @@ const RegisterClient = () => {
     }]);
   };
 
-  // ✅ SCHÉMA 4: Tunnel Complet (website → form → download)
+  // ✅ SCHÉMA 5: Tunnel Complet (website → form → download)
   const executeCompleteFunnelSchema = async (actions) => {
     console.log('🎯 Exécution: Tunnel Complet');
     
@@ -268,7 +296,29 @@ const RegisterClient = () => {
     }
   };
 
-  // ✅ SCHÉMA 5: Contact Uniquement (form seulement)
+  // ✅ SCHÉMA 5bis: Tunnel Complet, site en dernier (form → download → website)
+  const executeFunnelSiteLastSchema = async (actions) => {
+    console.log('🎯🌐 Exécution: Tunnel Complet - Site en dernier');
+    setShowForm(true);
+
+    const downloadAction = actions.find(a => a.type === 'download');
+    const websiteAction = actions.find(a => a.type === 'website');
+    const pending = [];
+    if (downloadAction) pending.push(downloadAction);
+    if (websiteAction) pending.push(websiteAction);
+
+    if (pending.length > 0) {
+      setPendingActions(pending);
+    }
+
+    setExecutionStatus([{
+      action: 'form',
+      status: 'form-shown',
+      message: 'Formulaire affiché - Actions après soumission'
+    }]);
+  };
+
+  // ✅ SCHÉMA 6: Contact Uniquement (form seulement)
   const executeContactOnlySchema = async (actions) => {
     console.log('📝 Exécution: Contact Uniquement');
     setShowForm(true);
@@ -279,7 +329,7 @@ const RegisterClient = () => {
     }]);
   };
 
-  // ✅ SCHÉMA 6: Carte de Visite (download seulement)
+  // ✅ SCHÉMA 7: Carte de Visite (download seulement)
   const executeCardDownloadSchema = async (actions) => {
     console.log('📥 Exécution: Carte de Visite');
     const downloadAction = actions.find(a => a.type === 'download');
@@ -335,6 +385,8 @@ const RegisterClient = () => {
         }]);
       }
     }
+
+    setPendingActions([]);
   };
 
   const handleDownloadAction = async (action) => {
@@ -421,9 +473,11 @@ const RegisterClient = () => {
   const getSchemaName = () => {
     switch (schemaType) {
       case 'website-only': return '🌐 Site Web Direct';
-      case 'lead-generation': return '🚀 Génération de Leads';
+      case 'lead-generation': return 'Génération de Leads';
+      case 'form-website': return '📝→🌐 Formulaire puis Site';
       case 'contact-download': return '📝 Contact → Carte';
       case 'complete-funnel': return '🎯 Tunnel Complet';
+      case 'funnel-site-last': return '🎯 Site en Dernier';
       case 'contact-only': return '📝 Contact Uniquement';
       case 'card-download': return '📥 Carte de Visite';
       case 'custom': return '🔧 Stratégie Personnalisée';

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # CRM Application.
-t
 Une application CRM complète avec gestion des clients et génération de devis.
-
 ## 🚀 Fonctionnalités
 
 - **Authentification** : Inscription et connexion sécurisées
@@ -9,6 +7,7 @@ Une application CRM complète avec gestion des clients et génération de devis.
 - **Génération de devis** : Création et édition de devis professionnels
 - **QR Code** : Génération de liens d'inscription pour les clients
 - **Export PDF** : Téléchargement des devis en format PDF
+- **Schémas d'actions** : Plusieurs séquences pour afficher site ou formulaire selon vos besoins
 
 ## 📋 Prérequis
 
@@ -187,3 +186,10 @@ Pour partager la configuration :
 1. Utilisez les fichiers `.env.example`
 2. Documentez les variables nécessaires
 3. Chaque développeur crée son propre `.env`
+
+## ❓ Résolution des problèmes
+
+Si vous scannez le QR code depuis un appareil mobile et obtenez l'erreur
+`ERR_CONNECTION_REFUSED`, assurez‑vous que le frontend est accessible depuis ce
+réseau. Utilisez un nom de domaine public ou un tunnel (ex. `ngrok`) plutôt que
+`localhost` pour que le lien soit reachable sur votre téléphone.


### PR DESCRIPTION
## Summary
- allow selecting 'Site en Dernier' schema with form and download first
- remove rocket emoji from lead-generation name
- detect new site-last sequence in client registration flow
- execute pending actions then clear the queue
- fix schema detection

## Testing
- `npm test --prefix Backend` *(fails: Error: no test specified)*
- `npm test --prefix Frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68476d71e588832dafb20ce7e52bbc92