### PR TITLE
fix: refresh stats automatically

### DIFF
--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.jsx
@@ -111,6 +111,15 @@ const BusinessCard = ({ userId, user }) => {
     }
   }, [cardConfig.actions, userId]);
 
+  // Rafraîchir périodiquement les statistiques pour refléter les scans récents
+  useEffect(() => {
+    if (!userId) return;
+    const intervalId = setInterval(() => {
+      fetchStats();
+    }, 5000);
+    return () => clearInterval(intervalId);
+  }, [userId]);
+
   const loadSavedBusinessCard = async () => {
     try {
       const savedCard = await apiRequest(API_ENDPOINTS.BUSINESS_CARDS.BASE);


### PR DESCRIPTION
## Summary
- refresh stats every 5 seconds on the Business Card page

## Testing
- `npm --prefix Frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684979a290a4832dab83531ad3f18bff