### PR TITLE
Update navbar profile picture automatically

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -42,6 +42,9 @@ const Settings = () => {
         email: userData.email || '',
         profileImage: userData.profileImage || ''
       }));
+      // Update localStorage and notify other components about the change
+      localStorage.setItem('user', JSON.stringify(userData));
+      window.dispatchEvent(new CustomEvent('userUpdated', { detail: userData }));
     } catch (error) {
       console.error('Erreur lors du chargement des données utilisateur:', error);
     }

--- a/Frontend/src/components/Navbar/index.jsx
+++ b/Frontend/src/components/Navbar/index.jsx
@@ -7,7 +7,10 @@ const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const token = localStorage.getItem("token");
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const userMenuRef = useRef(null);
@@ -17,6 +20,15 @@ const Navbar = () => {
       fetchUser();
     }
   }, [token]);
+
+  // Update user info when profile changes elsewhere
+  useEffect(() => {
+    const handleUserUpdated = (e) => {
+      setUser(e.detail);
+    };
+    window.addEventListener('userUpdated', handleUserUpdated);
+    return () => window.removeEventListener('userUpdated', handleUserUpdated);
+  }, []);
 
   // Fermer le menu utilisateur quand on clique ailleurs
   useEffect(() => {
@@ -36,6 +48,7 @@ const Navbar = () => {
     try {
       const userData = await apiRequest(API_ENDPOINTS.AUTH.ME);
       setUser(userData);
+      localStorage.setItem('user', JSON.stringify(userData));
     } catch (error) {
       console.error("Erreur lors du chargement de l'utilisateur:", error);
       handleLogout();

--- a/Frontend/src/pages/Login/Index.jsx
+++ b/Frontend/src/pages/Login/Index.jsx
@@ -63,6 +63,7 @@ const Login = () => {
       // Stocker les données d'authentification
       localStorage.setItem("token", data.token);
       localStorage.setItem("user", JSON.stringify(data.user));
+      window.dispatchEvent(new CustomEvent('userUpdated', { detail: data.user }));
       
       console.log("✅ Connexion réussie");
       

--- a/Frontend/src/pages/RegisterUser/Index.jsx
+++ b/Frontend/src/pages/RegisterUser/Index.jsx
@@ -98,6 +98,7 @@ const RegisterUser = () => {
       // 2. Store the token
       localStorage.setItem("token", userData.token);
       localStorage.setItem("user", JSON.stringify(userData.user));
+      window.dispatchEvent(new CustomEvent('userUpdated', { detail: userData.user }));
       
       // 3. Start the free trial
       await startFreeTrial(DEFAULT_TRIAL_DAYS);

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -37,6 +37,8 @@ const Settings = () => {
         email: userData.email || '',
         profileImage: userData.profileImage || ''
       }));
+      localStorage.setItem('user', JSON.stringify(userData));
+      window.dispatchEvent(new CustomEvent('userUpdated', { detail: userData }));
     } catch (error) {
       console.error('Erreur lors du chargement des données utilisateur:', error);
     }


### PR DESCRIPTION
## Summary
- update stored user data after profile edits
- dispatch `userUpdated` events when the profile changes
- listen for `userUpdated` in the navbar and update localStorage
- dispatch event after login and registration

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849e1b18528832d9cf213ff56276f83