### PR TITLE
Auto-refresh prospect list after import

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -11,7 +11,8 @@ import {
 } from '../../../services/subscription';
 import './settings.scss';
 
-const Settings = () => {
+// Ajout d'une prop onDataImported pour informer le parent après import
+const Settings = ({ onDataImported }) => {
   const [user, setUser] = useState({});
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -241,7 +242,7 @@ const Settings = () => {
     }
   };
 
-  const importData = async () => {
+const importData = async () => {
     const file = fileInputRef.current?.files[0];
     if (!file) {
       setMessage('❌ Sélectionnez un fichier à importer');
@@ -258,6 +259,9 @@ const Settings = () => {
         body: form,
       });
       setMessage('✅ Prospects importés avec succès');
+      if (typeof onDataImported === 'function') {
+        onDataImported();
+      }
     } catch (error) {
       setMessage(`❌ Erreur lors de l'import: ${error.message}`);
     } finally {

--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -507,7 +507,14 @@ const Dashboard = () => {
               />
             )}
             
-            {activeTab === "settings" && <Settings />}
+            {activeTab === "settings" && (
+              <Settings
+                onDataImported={() => {
+                  fetchClients();
+                  setActiveTab("clients");
+                }}
+              />
+            )}
             
             {activeTab === "carte" && (
               <BusinessCard 


### PR DESCRIPTION
## Summary
- notify parent after importing prospects in settings
- switch to prospect list and refresh when import completes

## Testing
- `npm run lint` *(fails: no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4799ce8832d88b4cf5869374a78