### PR TITLE
Fix prospect card layout

### DIFF
--- a/Frontend/src/components/Dashboard/Prospects/prospects.scss
+++ b/Frontend/src/components/Dashboard/Prospects/prospects.scss
@@ -378,7 +378,8 @@
   padding: 0.25rem 0.5rem;
   background: #f8fafc;
   border-radius: 6px;
-  width: 100%;
+  flex: 0 0 calc(50% - 0.5rem);
+  width: auto;
 }
 
 .contact-icon {
@@ -939,5 +940,8 @@
   .contact-info {
     flex-direction: column;
     align-items: flex-start;
+  }
+  .contact-item {
+    flex: 1 1 100%;
   }
 }


### PR DESCRIPTION
## Summary
- tweak prospect card CSS so contact fields line up in two-column layout
- make contact items full-width on small screens

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6bfdfac832da059498b0f2b43ab