### PR TITLE
Fix prospect card contact info layout

### DIFF
--- a/Frontend/src/components/Dashboard/Prospects/prospects.scss
+++ b/Frontend/src/components/Dashboard/Prospects/prospects.scss
@@ -378,7 +378,8 @@
   padding: 0.25rem 0.5rem;
   background: #f8fafc;
   border-radius: 6px;
-  width: 100%;
+  width: auto;
+  flex: 1 1 auto;
 }
 
 .contact-icon {
@@ -939,5 +940,8 @@
   .contact-info {
     flex-direction: column;
     align-items: flex-start;
+  }
+  .contact-item {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- tweak prospect contact info layout so details don't stack
- make mobile layout stack each contact item

## Testing
- `npm run lint` *(fails: 56 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6849e96d1a24832d8fe2ae1862b58b60