### PR TITLE
Enable prospect detail page via card click

### DIFF
--- a/Frontend/src/components/ClientCard/ClientCard.jsx
+++ b/Frontend/src/components/ClientCard/ClientCard.jsx
@@ -9,13 +9,17 @@ const ClientCard = ({
   onView,
   onEdit,
   onDelete,
-  onHistory
+  onHistory,
+  onCardClick
 }) => {
   const badgeClass = isActive ? 'bg-green-500' : 'bg-red-500';
   const badgeText = isActive ? 'ACTIF' : 'INACTIF';
 
   return (
-    <div className="w-full max-w-sm mx-auto bg-white rounded-xl shadow-md p-6 flex flex-col items-center space-y-4">
+    <div
+      className="w-full max-w-sm mx-auto bg-white rounded-xl shadow-md p-6 flex flex-col items-center space-y-4"
+      onClick={onCardClick}
+    >
       <div className="text-center">
         <h2 className="text-xl font-semibold capitalize">{name}</h2>
         <p className="flex items-center justify-center text-gray-500">
@@ -32,7 +36,7 @@ const ClientCard = ({
       <div className="flex gap-2">
         {onView && (
           <button
-            onClick={onView}
+            onClick={(e) => { e.stopPropagation(); onView(); }}
             className="bg-blue-50 text-blue-600 hover:bg-blue-100 rounded px-3 py-1 text-sm"
           >
             👁️ Voir
@@ -40,7 +44,7 @@ const ClientCard = ({
         )}
         {onEdit && (
           <button
-            onClick={onEdit}
+            onClick={(e) => { e.stopPropagation(); onEdit(); }}
             className="bg-yellow-50 text-yellow-600 hover:bg-yellow-100 rounded px-3 py-1 text-sm"
           >
             ✏️ Éditer
@@ -48,7 +52,7 @@ const ClientCard = ({
         )}
         {onDelete && (
           <button
-            onClick={onDelete}
+            onClick={(e) => { e.stopPropagation(); onDelete(); }}
             className="bg-red-50 text-red-600 hover:bg-red-100 rounded px-3 py-1 text-sm"
           >
             🗑️ Supprimer
@@ -56,7 +60,7 @@ const ClientCard = ({
         )}
         {onHistory && (
           <button
-            onClick={onHistory}
+            onClick={(e) => { e.stopPropagation(); onHistory(); }}
             className="bg-gray-50 text-gray-600 hover:bg-gray-100 rounded px-3 py-1 text-sm"
           >
             🕑 Historique

--- a/Frontend/src/components/Dashboard/Prospects/prospectDetails.scss
+++ b/Frontend/src/components/Dashboard/Prospects/prospectDetails.scss
@@ -1,0 +1,147 @@
+/* Styles for prospect details page */
+.prospect-detail-page {
+  padding: 2rem;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.detail-card {
+  background: white;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  border: 1px solid #f1f3f4;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.detail-title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.detail-title .avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.5rem;
+}
+
+.detail-info {
+  margin-bottom: 1.5rem;
+}
+
+.info-item {
+  background: #f8fafc;
+  padding: 1rem;
+  border-radius: 12px;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+/* Button styles copied from devis page */
+.card-btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  position: relative;
+  overflow: hidden;
+  font-weight: 600;
+  gap: 0.25rem;
+  padding: 0 0.75rem;
+}
+
+.card-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+  transition: left 0.5s ease;
+}
+
+.card-btn:hover::before {
+  left: 100%;
+}
+
+.card-btn-edit {
+  background: linear-gradient(135deg, #4299e1 0%, #3182ce 100%);
+  color: white;
+  flex: 1;
+  max-width: 100px;
+}
+
+.card-btn-edit:hover {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 4px 15px rgba(66, 153, 225, 0.3);
+}
+
+.card-btn-pdf {
+  background: linear-gradient(135deg, #ed8936 0%, #dd6b20 100%);
+  color: white;
+  flex: 1;
+  max-width: 100px;
+}
+
+.card-btn-pdf:hover {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 4px 15px rgba(237, 137, 54, 0.3);
+}
+
+.card-btn-invoice {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  color: white;
+  flex: 1;
+  max-width: 100px;
+}
+
+.card-btn-invoice:hover {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.3);
+}
+
+.card-btn-delete {
+  background: linear-gradient(135deg, #f56565 0%, #e53e3e 100%);
+  color: white;
+  width: 40px;
+  padding: 0;
+}
+
+.card-btn-delete:hover {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 4px 15px rgba(245, 101, 101, 0.3);
+}

--- a/Frontend/src/components/Dashboard/Prospects/prospectDetailsPage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectDetailsPage.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import './prospectDetails.scss';
+
+const ProspectDetailsPage = ({ prospect, onBack, onEdit }) => {
+  if (!prospect) {
+    return (
+      <div className="prospect-detail-page">
+        <div className="detail-card">
+          <p>Prospect introuvable.</p>
+          <div className="detail-actions">
+            <button onClick={onBack} className="card-btn card-btn-invoice">Retour</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="prospect-detail-page">
+      <div className="detail-card">
+        <div className="detail-header">
+          <button onClick={onBack} className="card-btn card-btn-pdf">← Retour</button>
+          <div className="detail-title">
+            <div className="avatar">
+              {prospect.name ? prospect.name.charAt(0).toUpperCase() : '?'}
+            </div>
+            <h2>{prospect.name}</h2>
+          </div>
+        </div>
+
+        <div className="detail-info">
+          <div className="info-item">📞 {prospect.phone || 'N/A'}</div>
+          <div className="info-item">🏢 {prospect.company || 'N/A'}</div>
+          {prospect.email && <div className="info-item">📧 {prospect.email}</div>}
+        </div>
+
+        <div className="detail-actions">
+          <button onClick={onEdit} className="card-btn card-btn-edit">✏️ Modifier</button>
+          <button onClick={onBack} className="card-btn card-btn-invoice">Retour</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProspectDetailsPage;

--- a/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
@@ -4,7 +4,15 @@ import { API_ENDPOINTS, apiRequest } from '../../../config/api';
 import ClientCard from '../../ClientCard';
 import './prospects.scss';
 
-const ProspectsPage = ({ clients = [], onRefresh, onViewClientDevis, onEditProspect, onViewClientBilling, onCreateProspect }) => {
+const ProspectsPage = ({
+  clients = [],
+  onRefresh,
+  onViewClientDevis,
+  onEditProspect,
+  onViewClientBilling,
+  onCreateProspect,
+  onViewProspect
+}) => {
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -470,6 +478,7 @@ const ProspectsPage = ({ clients = [], onRefresh, onViewClientDevis, onEditProsp
                 onEdit={() => onEditProspect && onEditProspect(prospect)}
                 onDelete={() => handleDeleteClient(prospect._id)}
                 onHistory={() => onViewClientBilling && onViewClientBilling(prospect)}
+                onCardClick={() => onViewProspect && onViewProspect(prospect)}
               />
             ))}
           </div>

--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -5,6 +5,7 @@ import DevisListPage from "../../components/Dashboard/Devis/devisListPage";
 import ProspectsPage from "../../components/Dashboard/Prospects/prospectsPage";
 import ProspectEditPage from "../../components/Dashboard/Prospects/prospectEditPage";
 import ProspectCreatePage from "../../components/Dashboard/Prospects/prospectCreatePage";
+import ProspectDetailsPage from "../../components/Dashboard/Prospects/prospectDetailsPage";
 import ClientBilling from "../../components/Dashboard/ClientBilling/clientBilling";
 import Analytics from "../../components/Dashboard/Analytics/analytics";
 import Settings from "../../components/Dashboard/Settings/settings";
@@ -229,6 +230,11 @@ const Dashboard = () => {
     setActiveTab("prospect-edit");
   };
 
+  const handleViewProspect = (prospect) => {
+    setSelectedProspect(prospect);
+    setActiveTab("prospect-view");
+  };
+
   // Définition des sections de navigation
   const navSections = [
     {
@@ -266,6 +272,7 @@ const Dashboard = () => {
       case "settings": return "Paramètres";
       case "prospect-edit": return "Modification Prospect";
       case "prospect-create": return "Nouveau Prospect";
+      case "prospect-view": return "Détails Prospect";
       default: return "CRM Pro";
     }
   };
@@ -282,6 +289,7 @@ const Dashboard = () => {
       case "settings": return "⚙️";
       case "prospect-edit": return "✏️";
       case "prospect-create": return "➕";
+      case "prospect-view": return "👁️";
       default: return "📊";
     }
   };
@@ -311,6 +319,7 @@ const Dashboard = () => {
                     (activeTab === "devis-creation" && item.id === "devis") ||
                     (activeTab === "prospect-edit" && item.id === "clients") ||
                     (activeTab === "prospect-create" && item.id === "clients") ||
+                    (activeTab === "prospect-view" && item.id === "clients") ||
                     (activeTab === "client-billing" && item.id === "devis")
                       ? "active"
                       : ""
@@ -323,7 +332,7 @@ const Dashboard = () => {
                       setSelectedClientForDevis(null);
                       setEditingDevis(null);
                     }
-                    if (item.id !== "clients" && item.id !== "prospect-edit" && item.id !== "prospect-create") {
+                    if (item.id !== "clients" && item.id !== "prospect-edit" && item.id !== "prospect-create" && item.id !== "prospect-view") {
                       setSelectedProspect(null);
                     }
                     if (item.id !== "client-billing") {
@@ -447,6 +456,7 @@ const Dashboard = () => {
                 onViewClientBilling={handleViewClientBilling}
                 onEditProspect={handleEditProspect}
                 onCreateProspect={handleCreateProspect}
+                onViewProspect={handleViewProspect}
               />
             )}
 
@@ -461,6 +471,19 @@ const Dashboard = () => {
                   fetchClients();
                   setSelectedProspect(null);
                   setActiveTab("clients");
+                }}
+              />
+            )}
+
+            {activeTab === "prospect-view" && selectedProspect && (
+              <ProspectDetailsPage
+                prospect={selectedProspect}
+                onBack={() => {
+                  setSelectedProspect(null);
+                  setActiveTab("clients");
+                }}
+                onEdit={() => {
+                  setActiveTab("prospect-edit");
                 }}
               />
             )}


### PR DESCRIPTION
## Summary
- add new `ProspectDetailsPage` component
- style prospect details page
- allow clicking on a prospect card to open details
- manage new page state in dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0eb1d90832d8f7b85e49a2df451