### PR TITLE
Add icons for cancel buttons

### DIFF
--- a/Frontend/src/components/Dashboard/Prospects/prospectCreatePage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectCreatePage.jsx
@@ -179,8 +179,9 @@ const ProspectCreatePage = ({ userId, onBack, onCreated }) => {
               type="button"
               onClick={onBack || (() => navigate(-1))}
               className="btn-cancel"
+              title="Annuler"
             >
-              Annuler
+              ✕
             </button>
             <button type="submit" className="btn-save" disabled={saving}>
               {saving ? 'Enregistrement...' : '💾 Enregistrer'}


### PR DESCRIPTION
## Summary
- tweak prospect creation cancel button to use `✕` icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6849f48ea144832da8b3b5041ad82960