### PR TITLE
Add styled file upload in settings

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -493,12 +493,18 @@ const importData = async () => {
             <p className="help-text">
               Téléchargez toutes vos données (clients, devis) au format JSON
             </p>
-            <input
-              type="file"
-              ref={fileInputRef}
-              accept=".csv,.xlsx"
-              style={{ marginTop: '0.5rem' }}
-            />
+            <div className="file-upload" style={{ marginTop: '0.5rem' }}>
+              <input
+                type="file"
+                id="prospects-file"
+                ref={fileInputRef}
+                accept=".csv,.xlsx"
+                disabled={loading}
+              />
+              <label htmlFor="prospects-file" className="upload-btn">
+                📂 Choisir un fichier
+              </label>
+            </div>
             <button onClick={importData} disabled={loading} className="import-btn" style={{ marginTop: '0.5rem' }}>
               📤 Importer des prospects
             </button>

--- a/Frontend/src/components/Dashboard/Settings/settings.scss
+++ b/Frontend/src/components/Dashboard/Settings/settings.scss
@@ -220,6 +220,39 @@
   background: linear-gradient(135deg, #059669 0%, #047857 100%) !important;
 }
 
+/* Style commun pour les imports de fichiers */
+.file-upload {
+  position: relative;
+  display: inline-block;
+}
+
+.file-upload input[type="file"] {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.upload-btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
+  color: white;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 500;
+  border: none;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.upload-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(29, 78, 216, 0.3);
+}
+
 .profile-preview {
   margin-top: 0.5rem;
   width: 80px;

--- a/Frontend/src/pages/Settings/settings.scss
+++ b/Frontend/src/pages/Settings/settings.scss
@@ -220,6 +220,38 @@
   background: linear-gradient(135deg, #059669 0%, #047857 100%) !important;
 }
 
+.file-upload {
+  position: relative;
+  display: inline-block;
+}
+
+.file-upload input[type="file"] {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.upload-btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
+  color: white;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 500;
+  border: none;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.upload-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(29, 78, 216, 0.3);
+}
+
 .profile-preview {
   margin-top: 0.5rem;
   width: 80px;


### PR DESCRIPTION
## Summary
- style the import prospects file input like the profile image upload
- reuse BusinessCard file-upload styles in Settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849f571bee4832d96aa9ba03bb4d090