### PR TITLE
Fix missing date formatter

### DIFF
--- a/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
+++ b/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
@@ -5,6 +5,15 @@ import DynamicInvoice from '../Billing/DynamicInvoice';
 import './devis.scss';
 import { calculateTTC } from '../../../utils/calculateTTC';
 
+const formatDate = (dateStr) => {
+  if (!dateStr) return '';
+  try {
+    return new Date(dateStr).toLocaleDateString('fr-FR');
+  } catch {
+    return '';
+  }
+};
+
 const DevisListPage = ({ clients = [], onEditDevis, onCreateDevis }) => {
   const navigate = useNavigate();
   const [devisList, setDevisList] = useState([]);


### PR DESCRIPTION
## Summary
- add missing `formatDate` helper to `DevisListPage` to avoid runtime error

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a217666c4832db557c987ee6a40d9