### PR TITLE
Fix notifications persist after logout

### DIFF
--- a/Frontend/src/components/Navbar/index.jsx
+++ b/Frontend/src/components/Navbar/index.jsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useState, useEffect, useRef } from "react";
+import { clearNotificationsStorage } from "../../utils/notifications";
 import { API_ENDPOINTS, apiRequest } from "../../config/api";
 import "./navbar.scss";
 
@@ -58,6 +59,7 @@ const Navbar = () => {
   const handleLogout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("user");
+    clearNotificationsStorage();
     setUser(null);
     navigate("/");
   };

--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -13,6 +13,7 @@ import Notifications from "../../components/Dashboard/Notifications/notification
 import BusinessCard from "../../components/Dashboard/BusinessCard/businessCard";
 import Billing from "../../components/Dashboard/Billing/billing";
 import { API_ENDPOINTS, apiRequest } from "../../config/api";
+import { clearNotificationsStorage } from "../../utils/notifications";
 import "./dashboard.scss";
 
 const Dashboard = () => {
@@ -148,6 +149,7 @@ const Dashboard = () => {
   const handleLogout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("user");
+    clearNotificationsStorage();
     navigate("/");
   };
 

--- a/Frontend/src/pages/Login/Index.jsx
+++ b/Frontend/src/pages/Login/Index.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link, useLocation } from "react-router-dom";
 import { API_ENDPOINTS, apiRequest } from "../../config/api";
+import { clearNotificationsStorage } from "../../utils/notifications";
 import "./login.scss";
 
 const Login = () => {
@@ -60,7 +61,8 @@ const Login = () => {
         }),
       });
 
-      // Stocker les données d'authentification
+      // Nettoyer les anciennes notifications puis stocker les données d'authentification
+      clearNotificationsStorage();
       localStorage.setItem("token", data.token);
       localStorage.setItem("user", JSON.stringify(data.user));
       window.dispatchEvent(new CustomEvent('userUpdated', { detail: data.user }));

--- a/Frontend/src/pages/RegisterUser/Index.jsx
+++ b/Frontend/src/pages/RegisterUser/Index.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { API_ENDPOINTS, apiRequest } from "../../config/api";
+import { clearNotificationsStorage } from "../../utils/notifications";
 import { startFreeTrial, DEFAULT_TRIAL_DAYS } from "../../services/subscription";
 import "./registerUser.scss";
 
@@ -95,7 +96,8 @@ const RegisterUser = () => {
         }),
       });
 
-      // 2. Store the token
+      // 2. Clear previous notifications and store the token
+      clearNotificationsStorage();
       localStorage.setItem("token", userData.token);
       localStorage.setItem("user", JSON.stringify(userData.user));
       window.dispatchEvent(new CustomEvent('userUpdated', { detail: userData.user }));

--- a/Frontend/src/utils/notifications.js
+++ b/Frontend/src/utils/notifications.js
@@ -1,0 +1,5 @@
+export const clearNotificationsStorage = () => {
+  localStorage.removeItem('notificationsData');
+  localStorage.removeItem('lastGeneratedTime');
+  localStorage.removeItem('deletedNotificationIds');
+};


### PR DESCRIPTION
## Summary
- add helper to clear notification-related localStorage
- clear notification data on logout, login and registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a2128d898832d88311e64c0b17174