### PR TITLE
Fix pricing badge clipping

### DIFF
--- a/Frontend/src/pages/Pricing/pricing.scss
+++ b/Frontend/src/pages/Pricing/pricing.scss
@@ -85,7 +85,7 @@
   padding: 3rem;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.1);
   position: relative;
-  overflow: hidden;
+  overflow: visible; /* allow badge to overflow */
   border: 1px solid #f1f5f9;
   transition: all 0.3s ease;
 }

--- a/src/pages/Pricing/pricing.scss
+++ b/src/pages/Pricing/pricing.scss
@@ -85,7 +85,7 @@
   padding: 3rem;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.1);
   position: relative;
-  overflow: hidden;
+  overflow: visible; /* allow badge to overflow */
   border: 1px solid #f1f5f9;
   transition: all 0.3s ease;
   animation: fadeInUp 0.6s ease-out 0.2s both;


### PR DESCRIPTION
## Summary
- allow the badge to overflow pricing cards so the ribbon isn't clipped

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a22e9a43c832d80efa72d7c56a1b2