### PR TITLE
Fix settings subscribe button style

### DIFF
--- a/Frontend/src/pages/Settings/settings.scss
+++ b/Frontend/src/pages/Settings/settings.scss
@@ -146,6 +146,34 @@
   cursor: not-allowed;
 }
 
+.subscribe-btn {
+  background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
+  color: white;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: block;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 8px 25px rgba(59, 130, 246, 0.2);
+  margin-top: 20px;
+}
+
+.subscribe-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #1d4ed8 0%, #2563eb 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 35px rgba(59, 130, 246, 0.3);
+}
+
+.subscribe-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
 .form-group {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- style subscription button in settings page

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` in Backend *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_684a27a07e68832d85a536d4054ab411