### PR TITLE
Add plan toggle controls

### DIFF
--- a/Frontend/src/components/Dashboard/BusinessCard/businessCard.scss
+++ b/Frontend/src/components/Dashboard/BusinessCard/businessCard.scss
@@ -926,6 +926,19 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
+.export-modal {
+  background: transparent;
+  box-shadow: none;
+  border: none;
+}
+
+.export-options {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  padding: 2rem;
+}
+
 .modal-header {
   display: flex;
   justify-content: space-between;

--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -379,32 +379,25 @@ const Settings = ({ onDataImported }) => {
             {subscription && subscription.status !== SUBSCRIPTION_STATUS.ACTIVE && (
               <div className="plan-selector">
                 <h4>Choisissez votre plan</h4>
-                <div className="plan-options">
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'selected' : ''}`}
+                <div className="plan-toggle">
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.MONTHLY.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.MONTHLY.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.MONTHLY.price}€/{SUBSCRIPTION_PLANS.MONTHLY.period}</div>
-                  </div>
-                  
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'selected' : ''}`}
+                    Mensuel
+                  </button>
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.QUARTERLY.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.QUARTERLY.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.QUARTERLY.price}€/{SUBSCRIPTION_PLANS.QUARTERLY.period}</div>
-                    <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</div>
-                  </div>
-                  
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'selected' : ''}`}
+                    Trimestriel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</span>
+                  </button>
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.ANNUAL.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.ANNUAL.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.ANNUAL.price}€/{SUBSCRIPTION_PLANS.ANNUAL.period}</div>
-                    <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</div>
-                  </div>
+                    Annuel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</span>
+                  </button>
                 </div>
               </div>
             )}

--- a/Frontend/src/pages/SubscriptionRequired/Index.jsx
+++ b/Frontend/src/pages/SubscriptionRequired/Index.jsx
@@ -127,33 +127,25 @@ const SubscriptionRequired = () => {
 
           <div className="plan-selector">
             <h3>Choisissez votre plan</h3>
-            <div className="plan-options">
-              <div 
-                className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'selected' : ''}`}
+            <div className="plan-toggle">
+              <button
+                className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'active' : ''}`}
                 onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.MONTHLY.id)}
               >
-                <div className="plan-name">{SUBSCRIPTION_PLANS.MONTHLY.name}</div>
-                <div className="plan-price">{SUBSCRIPTION_PLANS.MONTHLY.price}€/{SUBSCRIPTION_PLANS.MONTHLY.period}</div>
-                <div className="plan-savings">&nbsp;</div>
-              </div>
-              
-              <div 
-                className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'selected' : ''}`}
+                Mensuel
+              </button>
+              <button
+                className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'active' : ''}`}
                 onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.QUARTERLY.id)}
               >
-                <div className="plan-name">{SUBSCRIPTION_PLANS.QUARTERLY.name}</div>
-                <div className="plan-price">{SUBSCRIPTION_PLANS.QUARTERLY.price}€/{SUBSCRIPTION_PLANS.QUARTERLY.period}</div>
-                <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</div>
-              </div>
-              
-              <div 
-                className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'selected' : ''}`}
+                Trimestriel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</span>
+              </button>
+              <button
+                className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'active' : ''}`}
                 onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.ANNUAL.id)}
               >
-                <div className="plan-name">{SUBSCRIPTION_PLANS.ANNUAL.name}</div>
-                <div className="plan-price">{SUBSCRIPTION_PLANS.ANNUAL.price}€/{SUBSCRIPTION_PLANS.ANNUAL.period}</div>
-                <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</div>
-              </div>
+                Annuel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</span>
+              </button>
             </div>
           </div>
 

--- a/src/pages/Dashboard/Settings/settings.jsx
+++ b/src/pages/Dashboard/Settings/settings.jsx
@@ -353,32 +353,25 @@ const importData = async () => {
             {subscription && subscription.status !== SUBSCRIPTION_STATUS.ACTIVE && (
               <div className="plan-selector">
                 <h4>Choisissez votre plan</h4>
-                <div className="plan-options">
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'selected' : ''}`}
+                <div className="plan-toggle">
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.MONTHLY.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.MONTHLY.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.MONTHLY.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.MONTHLY.price}€/{SUBSCRIPTION_PLANS.MONTHLY.period}</div>
-                  </div>
-                  
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'selected' : ''}`}
+                    Mensuel
+                  </button>
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.QUARTERLY.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.QUARTERLY.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.QUARTERLY.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.QUARTERLY.price}€/{SUBSCRIPTION_PLANS.QUARTERLY.period}</div>
-                    <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</div>
-                  </div>
-                  
-                  <div 
-                    className={`plan-option ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'selected' : ''}`}
+                    Trimestriel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.QUARTERLY.savings}</span>
+                  </button>
+                  <button
+                    className={`toggle-btn ${selectedPlan === SUBSCRIPTION_PLANS.ANNUAL.id ? 'active' : ''}`}
                     onClick={() => setSelectedPlan(SUBSCRIPTION_PLANS.ANNUAL.id)}
                   >
-                    <div className="plan-name">{SUBSCRIPTION_PLANS.ANNUAL.name}</div>
-                    <div className="plan-price">{SUBSCRIPTION_PLANS.ANNUAL.price}€/{SUBSCRIPTION_PLANS.ANNUAL.period}</div>
-                    <div className="plan-savings">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</div>
-                  </div>
+                    Annuel <span className="savings-badge">Économisez {SUBSCRIPTION_PLANS.ANNUAL.savings}</span>
+                  </button>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- replace list of plan options with plan-toggle controls in SubscriptionRequired and Settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a292aaae8832d9eb934289f31fe29