### PR TITLE
Add export options

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -19,7 +19,8 @@
     "react-qr-code": "^2.0.15",
     "react-router-dom": "^6.26.0",
     "react-to-print": "^3.1.0",
-    "socket.io-client": "^4.7.4"
+    "socket.io-client": "^4.7.4",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -201,6 +201,8 @@ const Settings = () => {
     }
   };
 
+  const [exportFormat, setExportFormat] = useState('json');
+
   const exportData = async () => {
     try {
       setLoading(true);
@@ -216,16 +218,43 @@ const Settings = () => {
         exportDate: new Date().toISOString()
       };
 
-      const dataStr = JSON.stringify(exportData, null, 2);
-      const dataBlob = new Blob([dataStr], { type: 'application/json' });
-      const url = URL.createObjectURL(dataBlob);
-      
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `crm-export-${new Date().toISOString().split('T')[0]}.json`;
-      link.click();
-      
-      URL.revokeObjectURL(url);
+      const dateStr = new Date().toISOString().split('T')[0];
+
+      if (exportFormat === 'pdf') {
+        const { default: jsPDF } = await import('jspdf');
+        const pdf = new jsPDF();
+        const text = JSON.stringify(exportData, null, 2);
+        const lines = pdf.splitTextToSize(text, 180);
+        pdf.text(lines, 10, 10);
+        pdf.save(`crm-export-${dateStr}.pdf`);
+      } else if (exportFormat === 'xlsx') {
+        const XLSX = await import('xlsx');
+        const wb = XLSX.utils.book_new();
+        const wsClients = XLSX.utils.json_to_sheet(clients);
+        XLSX.utils.book_append_sheet(wb, wsClients, 'Clients');
+        const wsDevis = XLSX.utils.json_to_sheet(devis);
+        XLSX.utils.book_append_sheet(wb, wsDevis, 'Devis');
+        XLSX.writeFile(wb, `crm-export-${dateStr}.xlsx`);
+      } else if (exportFormat === 'vcf') {
+        const vcardStr = clients.map(c => `BEGIN:VCARD\nVERSION:3.0\nFN:${c.name}\nEMAIL:${c.email}\nTEL:${c.phone}\nORG:${c.company || ''}\nEND:VCARD`).join('\n');
+        const blob = new Blob([vcardStr], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `crm-export-${dateStr}.vcf`;
+        link.click();
+        URL.revokeObjectURL(url);
+      } else {
+        const dataStr = JSON.stringify(exportData, null, 2);
+        const dataBlob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(dataBlob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `crm-export-${dateStr}.json`;
+        link.click();
+        URL.revokeObjectURL(url);
+      }
+
       setMessage('✅ Données exportées avec succès');
     } catch (error) {
       setMessage(`❌ Erreur lors de l'export: ${error.message}`);
@@ -448,11 +477,19 @@ const Settings = () => {
         <section className="settings-section">
           <h3>📊 Gestion des données</h3>
           <div className="data-actions">
-            <button onClick={exportData} disabled={loading} className="export-btn">
-              📥 Exporter mes données
-            </button>
+            <div className="export-options">
+              <select value={exportFormat} onChange={e => setExportFormat(e.target.value)}>
+                <option value="json">JSON</option>
+                <option value="pdf">PDF</option>
+                <option value="xlsx">Excel</option>
+                <option value="vcf">vCard</option>
+              </select>
+              <button onClick={exportData} disabled={loading} className="export-btn">
+                📥 Exporter mes données
+              </button>
+            </div>
             <p className="help-text">
-              Téléchargez toutes vos données (clients, devis) au format JSON
+              Téléchargez toutes vos données (clients, devis) dans le format sélectionné
             </p>
           </div>
         </section>

--- a/src/pages/Dashboard/Settings/settings.jsx
+++ b/src/pages/Dashboard/Settings/settings.jsx
@@ -210,6 +210,8 @@ const Settings = ({ onDataImported }) => {
     }
   };
 
+  const [exportFormat, setExportFormat] = useState('json');
+
   const exportData = async () => {
     try {
       setLoading(true);
@@ -225,16 +227,43 @@ const Settings = ({ onDataImported }) => {
         exportDate: new Date().toISOString()
       };
 
-      const dataStr = JSON.stringify(exportData, null, 2);
-      const dataBlob = new Blob([dataStr], { type: 'application/json' });
-      const url = URL.createObjectURL(dataBlob);
-      
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `crm-export-${new Date().toISOString().split('T')[0]}.json`;
-      link.click();
-      
-      URL.revokeObjectURL(url);
+      const dateStr = new Date().toISOString().split('T')[0];
+
+      if (exportFormat === 'pdf') {
+        const { default: jsPDF } = await import('jspdf');
+        const pdf = new jsPDF();
+        const text = JSON.stringify(exportData, null, 2);
+        const lines = pdf.splitTextToSize(text, 180);
+        pdf.text(lines, 10, 10);
+        pdf.save(`crm-export-${dateStr}.pdf`);
+      } else if (exportFormat === 'xlsx') {
+        const XLSX = await import('xlsx');
+        const wb = XLSX.utils.book_new();
+        const wsClients = XLSX.utils.json_to_sheet(clients);
+        XLSX.utils.book_append_sheet(wb, wsClients, 'Clients');
+        const wsDevis = XLSX.utils.json_to_sheet(devis);
+        XLSX.utils.book_append_sheet(wb, wsDevis, 'Devis');
+        XLSX.writeFile(wb, `crm-export-${dateStr}.xlsx`);
+      } else if (exportFormat === 'vcf') {
+        const vcardStr = clients.map(c => `BEGIN:VCARD\nVERSION:3.0\nFN:${c.name}\nEMAIL:${c.email}\nTEL:${c.phone}\nORG:${c.company || ''}\nEND:VCARD`).join('\n');
+        const blob = new Blob([vcardStr], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `crm-export-${dateStr}.vcf`;
+        link.click();
+        URL.revokeObjectURL(url);
+      } else {
+        const dataStr = JSON.stringify(exportData, null, 2);
+        const dataBlob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(dataBlob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `crm-export-${dateStr}.json`;
+        link.click();
+        URL.revokeObjectURL(url);
+      }
+
       setMessage('✅ Données exportées avec succès');
     } catch (error) {
       setMessage(`❌ Erreur lors de l'export: ${error.message}`);
@@ -521,11 +550,19 @@ const importData = async () => {
         <section className="settings-section">
           <h3>📊 Gestion des données</h3>
           <div className="data-actions">
-            <button onClick={exportData} disabled={loading} className="export-btn">
-              📥 Exporter mes données
-            </button>
+            <div className="export-options">
+              <select value={exportFormat} onChange={e => setExportFormat(e.target.value)}>
+                <option value="json">JSON</option>
+                <option value="pdf">PDF</option>
+                <option value="xlsx">Excel</option>
+                <option value="vcf">vCard</option>
+              </select>
+              <button onClick={exportData} disabled={loading} className="export-btn">
+                📥 Exporter mes données
+              </button>
+            </div>
             <p className="help-text">
-              Téléchargez toutes vos données (clients, devis) au format JSON
+              Téléchargez toutes vos données (clients, devis) dans le format sélectionné
             </p>
             <div className="file-upload" style={{ marginTop: '0.5rem' }}>
               <input


### PR DESCRIPTION
## Summary
- allow exporting data in PDF, Excel and vCard formats
- add UI dropdown to choose export type
- include `xlsx` as a frontend dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a2c534028832d91a24953670ea853