### PR TITLE
Style subscription plan options

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.scss
+++ b/Frontend/src/components/Dashboard/Settings/settings.scss
@@ -167,6 +167,61 @@
   white-space: nowrap;
 }
 
+/* Plan selector */
+.plan-selector {
+  margin: 20px 0;
+}
+
+.plan-options {
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.plan-option {
+  background: #f8fafc;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  flex: 1;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.plan-option:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  border-color: #cbd5e1;
+}
+
+.plan-option.selected {
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  border-color: #3b82f6;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+}
+
+.plan-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
+  margin-bottom: 5px;
+}
+
+.plan-price {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #3b82f6;
+  margin-bottom: 5px;
+}
+
+.plan-savings {
+  font-size: 0.8rem;
+  color: #10b981;
+  font-weight: 600;
+}
+
 /* Subscription price display */
 .subscription-price-display {
   background: #f8fafc;


### PR DESCRIPTION
## Summary
- style the plan selector in Settings page so plan options are visually consistent

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a2d544940832d9a3f14c4d442acf5