### PR TITLE
Add import format dropdown

### DIFF
--- a/docs/ImportProspects.md
+++ b/docs/ImportProspects.md
@@ -18,5 +18,6 @@ Vous trouverez également des exemples aux formats JSON et VCF dans le dossier `
 1. Démarrer le serveur backend comme indiqué dans `Backend/README.md`.
 2. Ouvrir l'interface Frontend et se connecter.
 3. Accéder à **Paramètres** → **Gestion des données**.
-4. Sélectionner le fichier à importer (CSV, XLSX, JSON, PDF ou VCF) puis cliquer sur **Importer des prospects**.
+4. Choisir l'extension du fichier dans la liste déroulante (CSV, XLSX, JSON, PDF ou VCF), sélectionner le fichier puis cliquer sur **Importer des prospects**.
 5. Une notification confirme la réussite de l'import et les prospects apparaissent dans la page **Prospects**.
+

--- a/src/pages/Dashboard/Settings/settings.jsx
+++ b/src/pages/Dashboard/Settings/settings.jsx
@@ -211,6 +211,7 @@ const Settings = ({ onDataImported }) => {
   };
 
   const [exportFormat, setExportFormat] = useState('json');
+  const [importFormat, setImportFormat] = useState('csv');
 
   const exportData = async () => {
     try {
@@ -557,12 +558,21 @@ const importData = async () => {
             <p className="help-text">
               Téléchargez toutes vos données (clients, devis) dans le format sélectionné
             </p>
+            <div className="import-options" style={{ marginTop: '0.5rem' }}>
+              <select value={importFormat} onChange={e => setImportFormat(e.target.value)}>
+                <option value="csv">CSV</option>
+                <option value="xlsx">Excel</option>
+                <option value="json">JSON</option>
+                <option value="pdf">PDF</option>
+                <option value="vcf">vCard</option>
+              </select>
+            </div>
             <div className="file-upload" style={{ marginTop: '0.5rem' }}>
               <input
                 type="file"
                 id="prospects-file"
                 ref={fileInputRef}
-                accept=".csv,.xlsx"
+                accept={importFormat === 'vcf' ? '.vcf,.vcard' : `.${importFormat}`}
                 disabled={loading}
               />
               <label htmlFor="prospects-file" className="upload-btn">


### PR DESCRIPTION
## Summary
- add new `importFormat` state
- allow choosing format when importing prospects
- update docs to explain extension dropdown

## Testing
- `npm run lint -w Frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a3162bda0832db1a68374edf8b23f