### PR TITLE
Improve PDF export formatting

### DIFF
--- a/Frontend/src/components/Dashboard/Settings/settings.jsx
+++ b/Frontend/src/components/Dashboard/Settings/settings.jsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_TRIAL_DAYS,
   SUBSCRIPTION_PLANS
 } from '../../../services/subscription';
+import { generateExportPdf } from '../../../utils/generateExportPdf';
 import './settings.scss';
 
 // Ajout d'une prop onDataImported pour informer le parent après import
@@ -240,12 +241,7 @@ const Settings = ({ onDataImported }) => {
       const dateStr = new Date().toISOString().split('T')[0];
 
       if (exportFormat === 'pdf') {
-        const { default: jsPDF } = await import('jspdf');
-        const pdf = new jsPDF();
-        const text = JSON.stringify(exportData, null, 2);
-        const lines = pdf.splitTextToSize(text, 180);
-        pdf.text(lines, 10, 10);
-        pdf.save(`crm-export-${dateStr}.pdf`);
+        await generateExportPdf(exportData, dateStr);
       } else if (exportFormat === 'xlsx') {
         const XLSX = await import('xlsx');
         const wb = XLSX.utils.book_new();

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiRequest } from '../../config/api';
 import { getSubscriptionStatus, createPortalSession, createCheckoutSession, startFreeTrial, SUBSCRIPTION_STATUS, getTrialDaysRemaining, DEFAULT_TRIAL_DAYS } from '../../services/subscription';
+import { generateExportPdf } from '../../utils/generateExportPdf';
 
 import './settings.scss';
 
@@ -221,12 +222,7 @@ const Settings = () => {
       const dateStr = new Date().toISOString().split('T')[0];
 
       if (exportFormat === 'pdf') {
-        const { default: jsPDF } = await import('jspdf');
-        const pdf = new jsPDF();
-        const text = JSON.stringify(exportData, null, 2);
-        const lines = pdf.splitTextToSize(text, 180);
-        pdf.text(lines, 10, 10);
-        pdf.save(`crm-export-${dateStr}.pdf`);
+        await generateExportPdf(exportData, dateStr);
       } else if (exportFormat === 'xlsx') {
         const XLSX = await import('xlsx');
         const wb = XLSX.utils.book_new();

--- a/Frontend/src/utils/generateExportPdf.js
+++ b/Frontend/src/utils/generateExportPdf.js
@@ -1,0 +1,63 @@
+export const generateExportPdf = async (exportData, dateStr) => {
+  const { default: jsPDF } = await import('jspdf');
+  const margin = 10;
+  let y = margin + 5;
+  const pdf = new jsPDF();
+
+  pdf.setFontSize(18);
+  pdf.text('Export CRM', 105, y, { align: 'center' });
+  y += 10;
+  pdf.setFontSize(12);
+  pdf.text(`Date : ${dateStr}`, 105, y, { align: 'center' });
+  y += 15;
+
+  pdf.setFontSize(14);
+  pdf.text('Utilisateur', margin, y);
+  y += 8;
+  pdf.setFontSize(10);
+  if (exportData.user) {
+    if (exportData.user.name) {
+      pdf.text(`Nom : ${exportData.user.name}`, margin + 2, y);
+      y += 6;
+    }
+    if (exportData.user.email) {
+      pdf.text(`Email : ${exportData.user.email}`, margin + 2, y);
+      y += 6;
+    }
+  }
+
+  if (exportData.clients && exportData.clients.length) {
+    y += 4;
+    pdf.setFontSize(14);
+    pdf.text('Clients', margin, y);
+    y += 8;
+    pdf.setFontSize(10);
+    exportData.clients.forEach((client, idx) => {
+      pdf.text(`${idx + 1}. ${client.name || ''} - ${client.email || ''}`, margin + 2, y);
+      y += 6;
+      if (y > 280) {
+        pdf.addPage();
+        y = margin;
+      }
+    });
+  }
+
+  if (exportData.devis && exportData.devis.length) {
+    y += 4;
+    pdf.setFontSize(14);
+    pdf.text('Devis', margin, y);
+    y += 8;
+    pdf.setFontSize(10);
+    exportData.devis.forEach((devis, idx) => {
+      const date = devis.dateDevis ? devis.dateDevis.split('T')[0] : '';
+      pdf.text(`${idx + 1}. ${devis.title || 'Devis'} - ${date}`, margin + 2, y);
+      y += 6;
+      if (y > 280) {
+        pdf.addPage();
+        y = margin;
+      }
+    });
+  }
+
+  pdf.save(`crm-export-${dateStr}.pdf`);
+};


### PR DESCRIPTION
## Summary
- add new helper to style PDF exports
- use the helper when exporting data from the settings pages

## Testing
- `npm run lint` *(fails: lint errors)*
- `npm run build` in Frontend
- `npm run build` in Backend

------
https://chatgpt.com/codex/tasks/task_e_684a31aa458c832d94a0dd6f8264d524