### PR TITLE
Display selected pricing

### DIFF
--- a/Frontend/src/pages/Pricing/Index.jsx
+++ b/Frontend/src/pages/Pricing/Index.jsx
@@ -33,6 +33,11 @@ const Pricing = () => {
         </button>
       </div>
 
+      <div className="selected-plan-price">
+        {SUBSCRIPTION_PLANS[selectedPlan.toUpperCase()].price}€/
+        {SUBSCRIPTION_PLANS[selectedPlan.toUpperCase()].period}
+      </div>
+
       <div className="pricing-plans">
         {/* Plan Mensuel */}
         {selectedPlan === 'monthly' && (

--- a/Frontend/src/pages/Pricing/pricing.scss
+++ b/Frontend/src/pages/Pricing/pricing.scss
@@ -74,6 +74,14 @@
   white-space: nowrap;
 }
 
+.selected-plan-price {
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
 .pricing-container {
   max-width: 500px;
   margin: 0 auto 5rem;

--- a/src/pages/Pricing/Index.jsx
+++ b/src/pages/Pricing/Index.jsx
@@ -33,6 +33,11 @@ const Pricing = () => {
         </button>
       </div>
 
+      <div className="selected-plan-price">
+        {SUBSCRIPTION_PLANS[selectedPlan.toUpperCase()].price}€/
+        {SUBSCRIPTION_PLANS[selectedPlan.toUpperCase()].period}
+      </div>
+
       <div className="pricing-plans">
         {/* Plan Mensuel */}
         {selectedPlan === 'monthly' && (

--- a/src/pages/Pricing/pricing.scss
+++ b/src/pages/Pricing/pricing.scss
@@ -74,6 +74,14 @@
   white-space: nowrap;
 }
 
+.selected-plan-price {
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
 .pricing-plans {
   max-width: 800px;
   margin: 0 auto 5rem;


### PR DESCRIPTION
## Summary
- show cost directly under the plan selector
- style the price display

## Testing
- `npm run -w Frontend lint` *(fails: Cannot find package '@eslint/js')*
- `npm run -w Backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a32f024d4832da6e650e10c5c4310