### PR TITLE
Change history button title to facture

### DIFF
--- a/Frontend/src/components/ClientCard/ClientCard.jsx
+++ b/Frontend/src/components/ClientCard/ClientCard.jsx
@@ -155,9 +155,9 @@ const ClientCard = ({
           <button
             onClick={(e) => { e.stopPropagation(); onHistory(); }}
             className="bg-yellow-50 text-yellow-600 hover:bg-yellow-100 rounded px-3 py-1 text-sm"
-            title="Historique"
+            title="Facture"
           >
-            🕑 Historique
+            🕑 Facture
           </button>
         )}
       </div>

--- a/src/components/ClientCard/ClientCard.jsx
+++ b/src/components/ClientCard/ClientCard.jsx
@@ -142,9 +142,9 @@ const ClientCard = ({
           <button
             onClick={(e) => { e.stopPropagation(); onHistory(); }}
             className="bg-yellow-50 text-yellow-600 hover:bg-yellow-100 rounded px-3 py-1 text-sm"
-            title="Historique"
+            title="Facture"
           >
-            🕑 Historique
+            🕑 Facture
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- update ClientCard history button text to "Facture" in source and frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a3483c4b4832da69f2329a383bb27