### PR TITLE
Add prospect import option

### DIFF
--- a/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
+++ b/Frontend/src/components/Dashboard/Prospects/prospectsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiRequest } from '../../../config/api';
 import ClientCard from '../../ClientCard';
@@ -19,6 +19,8 @@ const ProspectsPage = ({
   const [sortBy, setSortBy] = useState('name');
   const [loading, setLoading] = useState(false);
   const [selectedProspects, setSelectedProspects] = useState([]);
+  const [importFormat, setImportFormat] = useState('csv');
+  const fileInputRef = useRef(null);
   
   // ✅ NOUVEAU: États pour la pagination
   const [currentPage, setCurrentPage] = useState(1);
@@ -284,6 +286,32 @@ const ProspectsPage = ({
     }
   };
 
+  const importData = async () => {
+    const file = fileInputRef.current?.files[0];
+    if (!file) {
+      alert('❌ Sélectionnez un fichier à importer');
+      return;
+    }
+    setLoading(true);
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      form.append('format', importFormat);
+      await apiRequest(API_ENDPOINTS.CLIENTS.IMPORT, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+        body: form,
+      });
+      alert('✅ Prospects importés avec succès');
+      onRefresh && onRefresh();
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    } catch (error) {
+      alert(`❌ Erreur lors de l'import: ${error.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   // ✅ NOUVELLE FONCTION: Formater l'adresse complète
   const formatAddress = (prospect) => {
     const parts = [];
@@ -389,7 +417,7 @@ const ProspectsPage = ({
 
           <div className="filter-actions">
             {selectedProspects.length > 0 && (
-              <button 
+              <button
                 onClick={handleBulkDelete}
                 className="bulk-delete-btn"
                 disabled={loading}
@@ -397,13 +425,39 @@ const ProspectsPage = ({
                 🗑️ Supprimer ({selectedProspects.length})
               </button>
             )}
-            
+
             <button
               onClick={onCreateProspect}
               className="cta-button"
             >
               ✨ Créer un prospect
             </button>
+            <div className="import-actions">
+              <select
+                value={importFormat}
+                onChange={(e) => setImportFormat(e.target.value)}
+                className="filter-select"
+              >
+                <option value="csv">CSV</option>
+                <option value="xlsx">Excel</option>
+                <option value="json">JSON</option>
+                <option value="pdf">PDF</option>
+                <option value="vcf">vCard</option>
+              </select>
+              <input
+                type="file"
+                ref={fileInputRef}
+                accept={importFormat === 'vcf' ? '.vcf,.vcard' : `.${importFormat}`}
+                disabled={loading}
+              />
+              <button
+                onClick={importData}
+                disabled={loading}
+                className="import-btn"
+              >
+                📤 Importer
+              </button>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow importing prospects from Prospects page
- include dropdown to choose file format and file picker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a3947e6cc832dac9ccf70eef14977