### PR TITLE
Fix status color initialization

### DIFF
--- a/Frontend/src/components/ClientCard/ClientCard.jsx
+++ b/Frontend/src/components/ClientCard/ClientCard.jsx
@@ -32,9 +32,6 @@ const ClientCard = ({
     }
   };
 
-  const badgeColor = status ? getStatusColor(status) : isActive ? '#48bb78' : '#f56565';
-  const badgeText = status ? getStatusLabel(status) : isActive ? 'ACTIF' : 'INACTIF';
-
   const getStatusColor = (status) => {
     switch (status) {
       case 'active':
@@ -49,6 +46,9 @@ const ClientCard = ({
         return '#4299e1';
     }
   };
+
+  const badgeColor = status ? getStatusColor(status) : isActive ? '#48bb78' : '#f56565';
+  const badgeText = status ? getStatusLabel(status) : isActive ? 'ACTIF' : 'INACTIF';
 
   const getStatusIcon = (status) => {
     switch (status) {


### PR DESCRIPTION
## Summary
- fix ClientCard status badge color by defining `getStatusColor` before use

## Testing
- `npm run lint` *(fails: cannot lint due to eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a3bf78a88832da8ab8c1ab1f18ddd