### PR TITLE
Add import format dropdown

### DIFF
--- a/docs/ImportProspects.md
+++ b/docs/ImportProspects.md
@@ -18,5 +18,6 @@ Vous trouverez également des exemples aux formats JSON et VCF dans le dossier `
 1. Démarrer le serveur backend comme indiqué dans `Backend/README.md`.
 2. Ouvrir l'interface Frontend et se connecter.
 3. Accéder à **Paramètres** → **Gestion des données**.
-4. Sélectionner le fichier à importer (CSV, XLSX, JSON, PDF ou VCF) puis cliquer sur **Importer des prospects**.
+4. Dans le bloc **Importer des prospects**, sélectionner d'abord le format désiré (CSV, XLSX, JSON, PDF ou VCF) dans la liste déroulante puis choisir le fichier correspondant avant de cliquer sur **Importer des prospects**. L'extension choisie est transmise à l'API dans le champ `format`.
 5. Une notification confirme la réussite de l'import et les prospects apparaissent dans la page **Prospects**.
+

--- a/src/pages/Dashboard/Settings/settings.jsx
+++ b/src/pages/Dashboard/Settings/settings.jsx
@@ -211,6 +211,7 @@ const Settings = ({ onDataImported }) => {
   };
 
   const [exportFormat, setExportFormat] = useState('json');
+  const [importFormat, setImportFormat] = useState('csv');
 
   const exportData = async () => {
     try {
@@ -283,6 +284,7 @@ const importData = async () => {
     try {
       const form = new FormData();
       form.append('file', file);
+      form.append('format', importFormat);
       await apiRequest(API_ENDPOINTS.CLIENTS.IMPORT, {
         method: 'POST',
         headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
@@ -557,21 +559,30 @@ const importData = async () => {
             <p className="help-text">
               Téléchargez toutes vos données (clients, devis) dans le format sélectionné
             </p>
-            <div className="file-upload" style={{ marginTop: '0.5rem' }}>
-              <input
-                type="file"
-                id="prospects-file"
-                ref={fileInputRef}
-                accept=".csv,.xlsx"
-                disabled={loading}
-              />
-              <label htmlFor="prospects-file" className="upload-btn">
-                📂 Choisir un fichier
-              </label>
+            <div className="import-options" style={{ marginTop: '0.5rem' }}>
+              <select value={importFormat} onChange={e => setImportFormat(e.target.value)}>
+                <option value="csv">CSV</option>
+                <option value="xlsx">Excel</option>
+                <option value="json">JSON</option>
+                <option value="pdf">PDF</option>
+                <option value="vcf">vCard</option>
+              </select>
+              <div className="file-upload" style={{ marginTop: '0.5rem' }}>
+                <input
+                  type="file"
+                  id="prospects-file"
+                  ref={fileInputRef}
+                  accept={importFormat === 'vcf' ? '.vcf,.vcard' : `.${importFormat}`}
+                  disabled={loading}
+                />
+                <label htmlFor="prospects-file" className="upload-btn">
+                  📂 Choisir un fichier
+                </label>
+              </div>
+              <button onClick={importData} disabled={loading} className="import-btn" style={{ marginTop: '0.5rem' }}>
+                📤 Importer des prospects
+              </button>
             </div>
-            <button onClick={importData} disabled={loading} className="import-btn" style={{ marginTop: '0.5rem' }}>
-              📤 Importer des prospects
-            </button>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- allow choosing import format via dropdown next to file picker
- document new import dropdown behavior

## Testing
- `npm run lint -w Frontend` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a3162bda0832db1a68374edf8b23f