### PR TITLE
Add formats info in settings

### DIFF
--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -548,6 +548,7 @@ const Settings = () => {
             <p><strong>Version:</strong> 1.0.0</p>
             <p><strong>Dernière connexion:</strong> {new Date().toLocaleDateString('fr-FR')}</p>
             <p><strong>ID utilisateur:</strong> {user.userId}</p>
+            <p><strong>Formats disponibles:</strong> PDF, CSV, Excel, JSON, vCard</p>
           </div>
         </section>
       </div>

--- a/src/pages/Dashboard/Settings/settings.jsx
+++ b/src/pages/Dashboard/Settings/settings.jsx
@@ -596,6 +596,7 @@ const importData = async () => {
             <p><strong>Version:</strong> 1.0.0</p>
             <p><strong>Dernière connexion:</strong> {new Date().toLocaleDateString('fr-FR')}</p>
             <p><strong>ID utilisateur:</strong> {user.userId}</p>
+            <p><strong>Formats disponibles:</strong> PDF, CSV, Excel, JSON, vCard</p>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- display available formats in the application info section for Settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a41725b10832d9fb6beba085b90e2