### PR TITLE
Fix Devis navigation from prospect

### DIFF
--- a/Frontend/src/pages/Dashboard/Index.jsx
+++ b/Frontend/src/pages/Dashboard/Index.jsx
@@ -121,7 +121,8 @@ const Dashboard = () => {
 
   const handleViewClientDevis = (client) => {
     setSelectedClientForDevis(client);
-    setActiveTab("devis-creation");
+    // Ouvrir la liste des devis pour pouvoir générer une facture
+    setActiveTab("devis");
   };
 
   const handleViewClientBilling = (client) => {


### PR DESCRIPTION
## Summary
- open the Devis list when clicking a prospect's "Devis" button

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684a4ae2be44832d90ed3ffc2fdacc29