### PR TITLE
Add theme toggle and update devis card titles

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript and enable type-aware lint rules. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Theme Toggle
+
+Use the sun/moon button in the navigation bar to switch between light and dark modes. Your preference is stored in localStorage.

--- a/Frontend/src/components/Dashboard/Billing/billing.jsx
+++ b/Frontend/src/components/Dashboard/Billing/billing.jsx
@@ -519,7 +519,7 @@ const Billing = ({ clients = [], onRefresh }) => {
                   onClick={() => handleSelectDevis(devis._id)}
                 >
                   <div className="devis-card-content">
-                    <h3 className="devis-card-title">{devis.title || "Devis sans titre"}</h3>
+                    <h3 className="devis-card-title">Devis {formatDate(devis.dateDevis)}</h3>
                     
                     <div className="devis-meta">
                       <div className="devis-client">

--- a/Frontend/src/components/Dashboard/ClientBilling/clientBilling.jsx
+++ b/Frontend/src/components/Dashboard/ClientBilling/clientBilling.jsx
@@ -664,7 +664,7 @@ const ClientBilling = ({ client, onBack }) => {
                   
                   <div className="devis-card-content">
                     <div className="devis-card-header">
-                      <h3 className="devis-card-title">{devis.title || "Devis sans titre"}</h3>
+                      <h3 className="devis-card-title">Devis {formatDate(devis.dateDevis)}</h3>
                       
                       <div className="devis-card-meta">
                         <div className="devis-card-date">

--- a/Frontend/src/components/Dashboard/Devis/DevisCard.jsx
+++ b/Frontend/src/components/Dashboard/Devis/DevisCard.jsx
@@ -16,7 +16,7 @@ const DevisCard = ({ devis, onEdit, onPdf, onDelete, loading = false }) => {
   return (
     <div className="devis-card">
       <div className="devis-card-header">
-        <h3 className="devis-card-title">{devis.title}</h3>
+        <h3 className="devis-card-title">Devis {formatDate(devis.dateDevis)}</h3>
         <div className="devis-card-meta">
           <span>📅 {formatDate(devis.dateDevis)}</span>
           <span className="devis-card-amount">💰 {ttc.toFixed(2)} € TTC</span>

--- a/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
+++ b/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
@@ -745,7 +745,7 @@ const DevisListPage = ({ clients = [], onEditDevis, onCreateDevis }) => {
                   {/* Section contenu principal */}
                   <div className="devis-card-content">
                     <div className="devis-card-header">
-                      <h3 className="devis-card-title">{devisItem.title || "Devis sans titre"}</h3>
+                      <h3 className="devis-card-title">Devis {formatDate(devisItem.dateDevis)}</h3>
                       
                       <div className="devis-card-meta">
                         <div className="devis-card-date">

--- a/Frontend/src/components/Navbar/index.jsx
+++ b/Frontend/src/components/Navbar/index.jsx
@@ -14,6 +14,7 @@ const Navbar = () => {
   });
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
   const userMenuRef = useRef(null);
 
   useEffect(() => {
@@ -44,6 +45,11 @@ const Navbar = () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   const fetchUser = async () => {
     try {
@@ -76,6 +82,10 @@ const Navbar = () => {
     setIsUserMenuOpen(!isUserMenuOpen);
   };
 
+  const toggleThemeMode = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
   // Masquer la navbar sur la page dashboard et sur les pages de scan QR code
   if (location.pathname === "/dashboard" || location.pathname.startsWith("/register-client/")) {
     return null;
@@ -92,7 +102,7 @@ const Navbar = () => {
         </div>
 
         {/* Menu burger pour mobile */}
-        <button 
+        <button
           className={`menu-toggle ${isMenuOpen ? 'active' : ''}`}
           onClick={toggleMenu}
           aria-label="Toggle menu"
@@ -100,6 +110,14 @@ const Navbar = () => {
           <span></span>
           <span></span>
           <span></span>
+        </button>
+
+        <button
+          className="theme-toggle"
+          onClick={toggleThemeMode}
+          aria-label="Toggle theme"
+        >
+          {theme === 'light' ? '🌙' : '☀️'}
         </button>
 
         <div className={`navbar-menu ${isMenuOpen ? 'active' : ''}`}>

--- a/Frontend/src/components/Navbar/navbar.scss
+++ b/Frontend/src/components/Navbar/navbar.scss
@@ -473,3 +473,16 @@
   outline: 2px solid #3b82f6;
   outline-offset: 2px;
 }
+
+.theme-toggle {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  margin-left: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+}

--- a/Frontend/src/utils/styles/colors.scss
+++ b/Frontend/src/utils/styles/colors.scss
@@ -7,3 +7,17 @@ $secondary: #BC9C23;
 $background: #FFFFFF;
 $text-dark: #2d3748;
 $accent: #f8ab37;
+
+:root {
+  --background: #FFFFFF;
+  --text-dark: #2d3748;
+  --primary-start: #667eea;
+  --primary-end: #764ba2;
+  --secondary: #BC9C23;
+  --accent: #f8ab37;
+}
+
+body.dark-mode {
+  --background: #1a202c;
+  --text-dark: #f9fafb;
+}

--- a/Frontend/src/utils/styles/global.scss
+++ b/Frontend/src/utils/styles/global.scss
@@ -13,7 +13,9 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: $background;
+  background-color: var(--background);
   color: $text-dark;
+  color: var(--text-dark);
   line-height: 1.6;
 }
 


### PR DESCRIPTION
## Summary
- implement theme toggle with button in Navbar
- add dark mode variables in SCSS
- use CSS variables for background and text color
- rename devis card headers to show the quote date
- document theme toggle usage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ac2442574832d990100625007317a