### PR TITLE
Fix undefined formatDate in DevisListPage

### DIFF
--- a/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
+++ b/Frontend/src/components/Dashboard/Devis/devisListPage.jsx
@@ -258,6 +258,15 @@ const DevisListPage = ({
     }
   };
 
+  const formatDate = (dateStr) => {
+    if (!dateStr) return "";
+    try {
+      return new Date(dateStr).toLocaleDateString("fr-FR");
+    } catch (error) {
+      return dateStr;
+    }
+  };
+
   // ✅ GÉNÉRATION PDF AVEC COUPURES AU NIVEAU DES LIGNES DE TABLEAU
   const handleDownloadPDF = async (devis) => {
     try {


### PR DESCRIPTION
## Summary
- define a `formatDate` helper inside `DevisListPage`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c9445f578832da36de7833f269874