### PR TITLE
Add invoice statistics endpoint and frontend display

### DIFF
--- a/Backend/routes/invoiceRoutes.js
+++ b/Backend/routes/invoiceRoutes.js
@@ -7,7 +7,8 @@ const {
   updateInvoice,
   updateInvoiceStatus,
   deleteInvoice,
-  sendInvoiceByEmail
+  sendInvoiceByEmail,
+  getInvoiceStats
 } = require("../controllers/invoiceController");
 const authMiddleware = require("../middleware/auth");
 const { checkSubscription } = require("../middleware/subscription");
@@ -37,5 +38,8 @@ router.post("/:id/send", authMiddleware, checkSubscription, sendInvoiceByEmail);
 
 // 📌 Supprimer une facture (DELETE)
 router.delete("/:id", authMiddleware, checkSubscription, deleteInvoice);
+
+// 📌 Obtenir les statistiques des factures (GET)
+router.get("/stats/summary", authMiddleware, checkSubscription, getInvoiceStats);
 
 module.exports = router;

--- a/Frontend/src/components/Dashboard/Billing/InvoiceList.jsx
+++ b/Frontend/src/components/Dashboard/Billing/InvoiceList.jsx
@@ -11,6 +11,16 @@ const InvoiceList = ({ clients = [] }) => {
   const [selectedClient, setSelectedClient] = useState(null);
   const [selectedDevis, setSelectedDevis] = useState([]);
   const invoicePreviewRef = useRef(null);
+
+  const [stats, setStats] = useState({
+    total: 0,
+    draft: 0,
+    pending: 0,
+    paid: 0,
+    overdue: 0,
+    canceled: 0,
+    totalAmount: 0
+  });
   
   // États pour filtres et recherche
   const [searchTerm, setSearchTerm] = useState('');
@@ -23,6 +33,7 @@ const InvoiceList = ({ clients = [] }) => {
 
   useEffect(() => {
     fetchInvoices();
+    fetchStats();
   }, []);
 
   const fetchInvoices = async () => {
@@ -35,6 +46,15 @@ const InvoiceList = ({ clients = [] }) => {
       setError("Erreur lors du chargement des factures");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchStats = async () => {
+    try {
+      const data = await apiRequest(API_ENDPOINTS.INVOICES.STATS);
+      if (data) setStats(data);
+    } catch (err) {
+      console.error('Erreur lors du chargement des statistiques de factures:', err);
     }
   };
 
@@ -87,8 +107,9 @@ const InvoiceList = ({ clients = [] }) => {
         method: 'PUT',
         body: JSON.stringify(updatedInvoice)
       });
-      
+
       await fetchInvoices();
+      await fetchStats();
       setSelectedInvoice(null);
       setSelectedClient(null);
       setSelectedDevis([]);
@@ -113,8 +134,9 @@ const InvoiceList = ({ clients = [] }) => {
       await apiRequest(API_ENDPOINTS.INVOICES.DELETE(invoiceId), {
         method: 'DELETE'
       });
-      
+
       await fetchInvoices();
+      await fetchStats();
       alert('✅ Facture supprimée avec succès');
     } catch (err) {
       console.error('Erreur lors de la suppression de la facture:', err);
@@ -154,8 +176,9 @@ const InvoiceList = ({ clients = [] }) => {
         method: 'PATCH',
         body: JSON.stringify({ status: newStatus })
       });
-      
+
       await fetchInvoices();
+      await fetchStats();
       alert(`✅ Statut de la facture mis à jour: ${getStatusLabel(newStatus)}`);
     } catch (err) {
       console.error('Erreur lors de la mise à jour du statut:', err);
@@ -412,7 +435,7 @@ const InvoiceList = ({ clients = [] }) => {
         <h2>📋 Mes Factures</h2>
         <div className="stats-summary">
           <div className="stat-item">
-            <span className="stat-number">{invoices.length}</span>
+            <span className="stat-number">{stats.total}</span>
             <span className="stat-label">Total</span>
           </div>
           <div className="stat-item">
@@ -420,23 +443,23 @@ const InvoiceList = ({ clients = [] }) => {
             <span className="stat-label">Affichés</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">{invoices.filter(i => i.status === 'draft').length}</span>
+            <span className="stat-number">{stats.draft}</span>
             <span className="stat-label">📝 Brouillons</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">{invoices.filter(i => i.status === 'pending').length}</span>
+            <span className="stat-number">{stats.pending}</span>
             <span className="stat-label">⏳ En attente</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">{invoices.filter(i => i.status === 'paid').length}</span>
+            <span className="stat-number">{stats.paid}</span>
             <span className="stat-label">✅ Payées</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">{invoices.filter(i => i.status === 'overdue').length}</span>
+            <span className="stat-number">{stats.overdue}</span>
             <span className="stat-label">⚠️ En retard</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">{invoices.filter(i => i.status === 'canceled').length}</span>
+            <span className="stat-number">{stats.canceled}</span>
             <span className="stat-label">❌ Annulées</span>
           </div>
         </div>

--- a/Frontend/src/config/api.js
+++ b/Frontend/src/config/api.js
@@ -48,6 +48,7 @@ export const API_ENDPOINTS = {
     UPDATE_STATUS: (invoiceId) => `${API_CONFIG.BASE_URL}/invoices/${invoiceId}/status`,
     DELETE: (invoiceId) => `${API_CONFIG.BASE_URL}/invoices/${invoiceId}`,
     SEND_BY_EMAIL: (invoiceId) => `${API_CONFIG.BASE_URL}/invoices/${invoiceId}/send`,
+    STATS: `${API_CONFIG.BASE_URL}/invoices/stats/summary`,
   },
 
   // Cartes de visite


### PR DESCRIPTION
## Summary
- expose new `/invoices/stats/summary` route
- compute invoice statistics in controller
- call stats API from invoice list and show numbers
- configure invoice stats endpoint in api config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c9a39b670832da7738c08a83b8247