### PR TITLE
Fix dark theme initialization

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -9,6 +9,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
+    <script>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'dark') {
+        document.body.classList.add('dark-mode');
+      }
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- load stored theme before app mount to apply dark mode immediately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: command sh -c eslint .)*

------
https://chatgpt.com/codex/tasks/task_e_6899db59ac2c832d825e63d01bf9399a